### PR TITLE
[Bugfix] Correctly interpolate the distribution_id environment variable

### DIFF
--- a/orbs/aws-cloudfront.yml
+++ b/orbs/aws-cloudfront.yml
@@ -39,4 +39,4 @@ commands:
       - run:
           name: Invalidate Cloudfront distribution << parameters.distribution_id >>
           command: |
-            aws cloudfront create-invalidation --distribution-id=<< parameters.distribution_id >> --paths=<< parameters.paths >>
+            aws cloudfront create-invalidation --distribution-id=${<< parameters.distribution_id >>} --paths=<< parameters.paths >>


### PR DESCRIPTION
`parameters.distribution_id` is an environment variable. As currently implemented, this will pass the name of the environment variable to the CLI, not the value.